### PR TITLE
 update Node.js to version 20 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION

### Title
 update Node.js to version 20 

### What does this PR do?
- Update node-version from 18 to 20 in .github/workflows/nodejs.yml
- Required for Docusaurus 3.9.1 compatibility



